### PR TITLE
docs: fix simple typo, subsribe -> subscribe

### DIFF
--- a/docs/hints/flag11.md
+++ b/docs/hints/flag11.md
@@ -1,3 +1,3 @@
 ## Flag 11 Hint
 
-Check out handle 0x0040 and google search gatt notify.  Some tools like gatttool have the ability to subsribe to gatt notifications
+Check out handle 0x0040 and google search gatt notify.  Some tools like gatttool have the ability to subscribe to gatt notifications


### PR DESCRIPTION
There is a small typo in docs/hints/flag11.md.

Should read `subscribe` rather than `subsribe`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md