### PR TITLE
Update README.md, changing 'bleah' to 'bettercap'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Submit using gatttool:
 ```` gatttool -b de:ad:be:ef:be:f1 --char-write-req -a 0x002c -n $(echo -n "some flag value"|xxd -ps) ````
 
 Submit using bettercap (requires ```` > ble.recon on ```` first):  
-```` > ble.write de:ad:be:ef:be:f1 ff02 3563643536643734303439616534306634343265636530333663366634663036 ````
+```` > ble.write de:ad:be:ef:be:f1 ff02 "some flag value" ````
 
 ### Flag Hints
 | Flag | Description | Hint |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to set up the CTF you will need the following:
 1. The pre-compiled firmware or source code in this repository to build and flash an ESP32 with the CTF GATT server.  
 2. An esp32 microcontroller ([I sell overpriced pre-flashed ones here](https://www.ebay.com/itm/173370426012?ssPageName=STRK:MESELX:IT&_trksid=p3984.m1558.l2649))
 3. A Linux box (OSX/Win + Linux VM works) with a bluetooth controller or a bluetooth usb dongle
-4. Bluetooth tools such as Bluez tools (hcitool, gatttool, etc) or [bleah](https://github.com/evilsocket/bleah)
+4. Bluetooth tools such as Bluez tools (hcitool, gatttool, etc) or [bettercap]([https://github.com/evilsocket/bleah](https://github.com/bettercap/bettercap))
 
 For instructions to compile/flash your own firmware or flash the provided pre-compiled firmware [read this documentation](docs/setup.md)
 
@@ -21,24 +21,25 @@ Before you can submit flags, you have to discover the Bluetooth MAC address of y
 Discover MAC using hcitool:   
 ```` sudo hcitool lescan ````
 
-Discover MAC using bleah:   
-```` sudo bleah ````
+Discover MAC using bettercap:   
+```` sudo bettercap ````
+```` > ble.recon on ````
 
 Now that you have found your device’s MAC address, you can now communicate with it.  Before we get started with flags, let’s check out how we can see our current score.  In order to see where you are in the CTF, you can read from handle 42 on the device to see how many flags you have.  The following are example commands of how to view your current score.  Make sure you replace the MAC address in the example commands with the MAC address of your device. 
 
 Show score with gatttool:  
 ```` gatttool -b de:ad:be:ef:be:f1 --char-read -a 0x002a|awk -F':' '{print $2}'|tr -d ' '|xxd -r -p;printf '\n'  ````
 
-Show score with bleah:  
-```` sudo bleah -b "30:ae:a4:20:79:da" -e ````
+Show score with bettercap (requires ```` > ble.recon on ```` first):  
+```` > ble.enum de:ad:be:ef:be:f1 ````
 
 Ok, ok, ok, on to the flags! All flags are md5 sums truncated to 20 characters to avoid MTU limits by some hardware.  They can be submitted to the gatt server on handle 44.  The following are examples of how to submit a flag.  Make sure you replace the MAC address in the example commands with the MAC address of your device:   
 
 Submit using gatttool:  
 ```` gatttool -b de:ad:be:ef:be:f1 --char-write-req -a 0x002c -n $(echo -n "some flag value"|xxd -ps) ````
 
-Submit using bleah:  
-```` sudo bleah -b "30:ae:a4:20:79:da" -n 0x002c -d "some flag value" ````
+Submit using bettercap (requires ```` > ble.recon on ```` first):  
+```` > ble.write de:ad:be:ef:be:f1 ff02 3563643536643734303439616534306634343265636530333663366634663036 ````
 
 ### Flag Hints
 | Flag | Description | Hint |


### PR DESCRIPTION
Updating the references to 'bleah', because it's deprecated, as this tool has been ported to 'bettercap' modules

Congrats for the nice work, we gonna play with this CTF on Laboratório Hacker de Campinas!